### PR TITLE
Rework default template/prompt variables.

### DIFF
--- a/lib/copy.js
+++ b/lib/copy.js
@@ -1,14 +1,42 @@
 
 var template = require('lodash/string/template');
+var isFunction = require('lodash/lang/isFunction');
+var isString = require('lodash/lang/isString');
+var assign = require('lodash/object/assign');
 
-function copy(dst, src) {
-	if (!src) {
-		src = dst;
+function copy(dst, src, options) {
+	var params;
+
+	if (isFunction(dst)) {
+		params = dst;
+	} else {
+		if (!isString(src)) {
+			options = src;
+			src = dst;
+		}
+		params = function() {
+			return assign({
+				source: src,
+				destination: dst
+			}, options);
+		}
 	}
 
 	return function() {
-		var tpl = template(this.fs.read(this.templatePath(src)));
-		this.fs.write(this.destinationPath(dst), tpl(this));
+		var vals = assign({
+			overwrite: true
+		}, params.call(this));
+
+		var d = this.destinationPath(vals.destination);
+		var s = this.templatePath(vals.source);
+		var e = this.fs.exists(d);
+
+		if (!vals.overwrite && e) {
+			return;
+		}
+
+		var tpl = template(this.fs.read(s));
+		this.fs.write(d, tpl(this.data));
 	}
 }
 

--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -1,0 +1,23 @@
+
+var defaults = require('lodash/object/defaults');
+var isFunction = require('lodash/lang/isFunction');
+var has = require('lodash/object/has');
+
+function get(val) {
+
+	var call;
+	if (!isFunction(val)) {
+		call = function() { return val; }
+	} else {
+		call = val;
+	}
+
+	return function() {
+		if (!has(this, 'data')) {
+			this.data = { };
+		}
+		defaults(this.data, call.call(this));
+	}
+}
+
+module.exports = get;

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,6 +1,8 @@
 
 module.exports = {
 	copy: require('./copy'),
+	defaults: require('./defaults'),
 	manifest: require('./manifest'),
-	open: require('./open')
+	open: require('./open'),
+	prompt: require('./prompt')
 };

--- a/lib/manifest.js
+++ b/lib/manifest.js
@@ -17,8 +17,9 @@ function manifest() {
 		var choices = [ 'package.json', 'package.json5' ];
 		var src = find(map(choices, path, this), exists, this);
 		var dst = this.destinationPath('package.json');
-		var input = template(this.fs.read(src))(this);
-		this.fs.write(dst, merge(this.fs.read(dst), input));
+		var input = template(this.fs.read(src))(this.data);
+		var newpkg = merge(this.fs.read(dst), input);
+		this.fs.write(dst, newpkg);
 		this.npmInstall();
 	}
 }

--- a/lib/prompt.js
+++ b/lib/prompt.js
@@ -1,0 +1,21 @@
+
+var assign = require('lodash/object/assign');
+var map = require('lodash/collection/map');
+
+function prompt(options) {
+	return function() {
+		var done = this.async(), data = this.data;
+		options = map(options, function(values) {
+			return assign({
+				default: data[values.name]
+			}, values);
+		});
+
+		this.prompt(options, function (answers) {
+			assign(this.data, answers);
+			done();
+		}.bind(this));
+	}
+}
+
+module.exports = prompt;


### PR DESCRIPTION
Use a `data` property on `this` to store prompt results since conflicting variables names can abound (e.g. a prompt using `env` will cause funny errors). To facilitate this include two new helpers for populating `this.data` – one for defaults and one for prompting.
