### PR TITLE
Handle case where `package.json` is missing.

### DIFF
--- a/lib/manifest.js
+++ b/lib/manifest.js
@@ -18,8 +18,14 @@ function manifest() {
 		var src = find(map(choices, path, this), exists, this);
 		var dst = this.destinationPath('package.json');
 		var input = template(this.fs.read(src))(this.data);
-		var newpkg = merge(this.fs.read(dst), input);
-		this.fs.write(dst, newpkg);
+		if (this.fs.exists(dst)) {
+			var newpkg = merge(this.fs.read(dst), input);
+			this.fs.write(dst, newpkg);
+		} else {
+			var obj = JSON.parse(input);
+			var newpkg = JSON.stringify(input, null, '\t');
+			this.fs.write(dst, newpkg);
+		}
 		this.npmInstall();
 	}
 }


### PR DESCRIPTION
When there is no existing `package.json` then create a new one using a sane default template.
