### PR TITLE
Add templated paths.

### DIFF
--- a/lib/copy.js
+++ b/lib/copy.js
@@ -3,6 +3,7 @@ var template = require('lodash/string/template');
 var isFunction = require('lodash/lang/isFunction');
 var isString = require('lodash/lang/isString');
 var assign = require('lodash/object/assign');
+var path = require('./path');
 
 function copy(dst, src, options) {
 	var params;
@@ -27,8 +28,8 @@ function copy(dst, src, options) {
 			overwrite: true
 		}, params.call(this));
 
-		var d = this.destinationPath(vals.destination);
-		var s = this.templatePath(vals.source);
+		var d = path.call(this, vals.destination);
+		var s = path.call(this, vals.source);
 		var e = this.fs.exists(d);
 
 		if (!vals.overwrite && e) {

--- a/lib/path.js
+++ b/lib/path.js
@@ -1,0 +1,16 @@
+
+var map = require('lodash/collection/map');
+var template = require('lodash/string/template');
+
+function path(str, data) {
+	var res = map(str.split('/'), function(part) {
+		return template(part)(data);
+	}).join('/');
+	if (res.charAt(0) === '~') {
+		return this.destinationPath(res.substr(1));
+	} else {
+		return this.templatePath(res);
+	}
+}
+
+module.exports = path;


### PR DESCRIPTION
Now by default all relative paths start in the template directory. There is a special modifier character (`~`) which changes this to the destination directory. Additionally you can use `lodash` templates in the string to generate path parts. e.g. `/foo/<%=val%>/bar`. Each template part is properly escaped, so returning special characters in the template part is totally fine.
