### PR TITLE
Don't use `JSON.parse` and default to 2 spaces.

### DIFF
--- a/lib/manifest.js
+++ b/lib/manifest.js
@@ -22,9 +22,9 @@ function manifest() {
 			var newpkg = merge(this.fs.read(dst), input);
 			this.fs.write(dst, newpkg);
 		} else {
-			var obj = JSON.parse(input);
-			var newpkg = JSON.stringify(obj, null, '\t');
-			this.fs.write(dst, newpkg);
+			this.fs.write(dst, merge(JSON.stringify({
+				version: '0.1.0'
+			}, null, '  '), input));
 		}
 		this.npmInstall();
 	}


### PR DESCRIPTION
Since some packages use JSON5 in the templates this is problematic. Simple call merge on an almost empty object - it needs at least one property to be able to infer indentation, so we pick a simple version default.
